### PR TITLE
camera: mcd_v2: treat EFS tilt/gyro cal size 0 as absent sensor, not an error

### DIFF
--- a/drivers/media/platform/exynos/camera/vendor/mcd_v2/is-vender-caminfo.c
+++ b/drivers/media/platform/exynos/camera/vendor/mcd_v2/is-vender-caminfo.c
@@ -149,6 +149,14 @@ static int is_vender_caminfo_set_efs_data(void __user *p_efsdata_user)
 			ret = -EINVAL;
 			goto EXIT;
 		}
+	} else if (efs_data.tilt_cal_tele_efs_size == 0) {
+		/*
+		 * Size 0 means this device has no telephoto camera.
+		 * That is a normal hardware configuration, not an error, so do
+		 * not fail the whole ioctl: returning -EFAULT here also discards
+		 * the successfully copied blocks below and makes the camera HAL
+		 * treat the entire EFS handoff as failed.
+		 */
 	} else {
 		err("wrong tilt cal tele data size : data size must be smaller than max size.(%d)", efs_data.tilt_cal_tele_efs_size);
 		ret = -EFAULT;
@@ -161,6 +169,14 @@ static int is_vender_caminfo_set_efs_data(void __user *p_efsdata_user)
 			ret = -EINVAL;
 			goto EXIT;
 		}
+	} else if (efs_data.tilt_cal_tele2_efs_size == 0) {
+		/*
+		 * Size 0 means this device has no second telephoto camera.
+		 * That is a normal hardware configuration, not an error, so do
+		 * not fail the whole ioctl: returning -EFAULT here also discards
+		 * the successfully copied blocks below and makes the camera HAL
+		 * treat the entire EFS handoff as failed.
+		 */
 	} else {
 		err("wrong tilt cal tele2 data size : data size must be smaller than max size.(%d)", efs_data.tilt_cal_tele2_efs_size);
 		ret = -EFAULT;
@@ -173,6 +189,14 @@ static int is_vender_caminfo_set_efs_data(void __user *p_efsdata_user)
 			ret = -EINVAL;
 			goto EXIT;
 		}
+	} else if (efs_data.gyro_efs_size == 0) {
+		/*
+		 * Size 0 means this device has no gyro calibration data.
+		 * That is a normal hardware configuration, not an error, so do
+		 * not fail the whole ioctl: returning -EFAULT here also discards
+		 * the successfully copied blocks below and makes the camera HAL
+		 * treat the entire EFS handoff as failed.
+		 */
 	} else {
 		err("wrong gyro data size : data size must be smaller than max size.(%d)", efs_data.gyro_efs_size);
 		ret = -EFAULT;


### PR DESCRIPTION
## Problem

`is_vender_caminfo_set_efs_data()` treats an EFS calibration block of size **0** as a
fatal error. On devices with no telephoto camera (a53x among them), the userspace
HAL legitimately passes `tilt_cal_tele_efs_size = 0` and `tilt_cal_tele2_efs_size = 0`
because there is no such sensor to calibrate.

The current code returns `-EFAULT` in that case. Because the return value is shared
across the whole ioctl, this **also discards the blocks that were copied
successfully afterwards**, so the entire EFS handoff is reported as failed rather
than just the absent one.

Observed on a53x (SM-A536E), every camera open:

```
[@][ERR]is_vender_caminfo_set_efs_data:153:wrong tilt cal tele data size : data size must be smaller than max size.(0)
[@][ERR]is_vender_caminfo_set_efs_data:165:wrong tilt cal tele2 data size : data size must be smaller than max size.(0)
```

Note the reported size is `(0)`, and the message claims the size must be *smaller*
than the maximum, which 0 already is. Size 0 is a normal hardware configuration,
not an oversized buffer.

## Fix

Treat size 0 as "this device does not have this sensor": skip the copy and leave
`ret` untouched, so the remaining blocks are still handed over. Sizes larger than
the maximum keep returning `-EFAULT` exactly as before.

Applied to all three blocks that had the same pattern (`tilt_cal_tele`,
`tilt_cal_tele2`, `gyro`). On a53x only the two tele blocks fire in practice; the
gyro guard is defensive and costs nothing.

## Verification on hardware

Built with the repo's own CI and flashed to a real SM-A536E running a LineageOS
23.2 GSI.

```
uname -r -> 5.10.266-Floppy-v6.3.3-KN-g7062bcdc7e98
```

The version string embeds the commit, so there is no ambiguity about which kernel
produced the result. Camera modules are modular and refuse to load on a vermagic
mismatch, so the loaded `is_*` modules necessarily came from this build too.

| measurement | before | after |
| ----------- | ------ | ----- |
| `wrong ... data size` errors | 2 | **0** |
| `is_vender_caminfo` invocations | present | 90 |
| camera functional | yes | yes |

Zero rejections across 90 `is_vender_caminfo` invocations and 5 camera-provider
restarts. Each provider restart re-runs the EFS handoff, so an unpatched kernel
produces roughly 10+ errors in the same session against a baseline of 2. It
produced none.

The base moved 5.10.260 -> 5.10.266 in the same flash, but that cannot explain this
result: upstream stable does not touch Samsung's out-of-tree
`is-vender-caminfo.c`.

## Scope, stated honestly

This fixes a real kernel bug and removes the bogus error path. It was originally
hypothesised to also fix a camera HAL crash on GSIs; **it does not**, and that
crash has since been traced to a completely separate userspace issue (the Eden NPU
runtime being unloaded while its worker threads are still running). This PR makes
no claim about that.

Affects every non-telephoto device on this kernel, not just a53x.
