### PR TITLE
ci: persist the ccache directory across workflow runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,21 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      # ckbuild.sh sets USE_CCACHE=1 and build.sh exports CC="ccache clang",
+      # so ccache is already in the compile path. What was missing is a cache
+      # directory that survives the job, plus the settings that let a restored
+      # cache actually hit.
+      # NOTE: CCACHE_DIR is deliberately NOT set here. Job-level env cannot use
+      # the runner context; it is exported from the Configure ccache step below.
+      # Required. The default compilercheck is "mtime", and a fresh checkout
+      # gives the vendored clang a new mtime on every run, so every object would
+      # miss and the restored cache would be dead weight. Hash the contents.
+      CCACHE_COMPILERCHECK: content
+      CCACHE_BASEDIR: ${{ github.workspace }}
+      CCACHE_NOHASHDIR: "true"
+      CCACHE_MAXSIZE: 2G
+      CCACHE_SLOPPINESS: time_macros,include_file_mtime,include_file_ctime,file_stat_matches
     steps:
 
       - name: Checkout repo
@@ -26,12 +41,35 @@ jobs:
           echo "${{ secrets.CHAT_ID }}" >> "../chat_ci"
           echo "${{ secrets.TOKEN }}" >> "../bot_token"
 
+      - name: Restore ccache
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/ccache
+          # Save a fresh entry every run, restore the most recent previous one.
+          # ccache is content-addressed, so a cache from an older commit is still
+          # almost entirely valid: a one-file change recompiles one object.
+          key: ccache-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            ccache-${{ runner.os }}-
+
+      - name: Configure ccache
+        run: |
+          # RUNNER_TEMP is available to the shell; ${{ runner.temp }} is not
+          # usable in job-level env, so publish CCACHE_DIR for later steps here.
+          echo "CCACHE_DIR=$RUNNER_TEMP/ccache" >> "$GITHUB_ENV"
+          export CCACHE_DIR="$RUNNER_TEMP/ccache"
+          mkdir -p "$CCACHE_DIR"
+          ccache -M 2G
+          ccache -z
+          ccache -s
+
       - name: Build (KernelSU Next)
         run: |
           rm -f kernel_build/*.zip kernel_build/*.tar kernel_build/TARs_*.zip log.txt || true
           rm -rf kernel_build/images || true
           mkdir -p kernel_build/images
           ./do_build.sh tkq
+          ccache -s
 
       - name: Prepare artifacts (KernelSU Next)
         id: artifacts_tk
@@ -94,6 +132,7 @@ jobs:
           rm -rf kernel_build/images || true
           mkdir -p kernel_build/images
           ./do_build.sh tsq
+          ccache -s
 
       - name: Prepare artifacts (SukiSU Ultra)
         id: artifacts_ts
@@ -156,6 +195,7 @@ jobs:
           rm -rf kernel_build/images || true
           mkdir -p kernel_build/images
           ./do_build.sh tuq
+          ccache -s
 
       - name: Prepare artifacts (MamboSU)
         id: artifacts_tu
@@ -218,6 +258,7 @@ jobs:
           rm -rf kernel_build/images || true
           mkdir -p kernel_build/images
           ./do_build.sh tq
+          ccache -s
 
       - name: Prepare artifacts (Vanilla)
         id: artifacts_t


### PR DESCRIPTION
## Problem

ccache is already in the compile path: `ckbuild.sh` sets `USE_CCACHE=1` and
`build.sh` exports `CC="ccache clang"`. What is missing is a cache directory that
survives the job.

`prep_build` only assigns `CCACHE_DIR` when it detects Gitpod, and otherwise just
warns. On GitHub Actions that means every run writes its cache into a directory
the runner then throws away, so every run compiles from cold.

## Fix

Restore and save the cache with `actions/cache@v4`, and set the ccache options
that let a restored cache actually hit.

`CCACHE_COMPILERCHECK=content` is the load-bearing one. The default is `mtime`,
and a fresh checkout gives the vendored clang a new mtime on every run, so
without it every object misses and the restored cache is dead weight.

`CCACHE_DIR` is exported from the `Configure ccache` step via `$GITHUB_ENV`
rather than set in job-level `env:`, because the `runner` context is not
available there. (That mistake produces a workflow that fails to parse, so it is
worth the comment that is in the diff.)

The cache key is per-commit with a prefix restore-key, so each run saves a fresh
entry and restores the most recent previous one. ccache is content addressed, so
a cache from an older commit is still almost entirely valid: a one-file change
recompiles one object.

## Measured

Same commit, same variant, this repo's own CI:

| run | Build (KernelSU Next) | cache |
| --- | --------------------- | ----- |
| 34706574749 | 33.0 min | cold |
| 34711251920 | 13.3 min | warm |

**2.5x**, roughly 20 minutes off a full four-variant run.

One note on methodology, because it is easy to get wrong: comparing variant 1
against variants 2 to 4 *inside a single run* suggests a much larger speedup, but
that is measuring incremental make, not ccache. `ckbuild.sh` only cleans when
passed the `c` argument, so later variants in the same run skip most targets
outright and never invoke the compiler at all. Only a cross-run comparison on an
identical commit isolates what the cache is worth, and that gives 2.5x.

`ccache -s` now prints after each variant, so the hit rate is visible in the log
rather than assumed.

## Scope

One file, `.github/workflows/build.yml`. No change to the kernel, to
`ckbuild.sh`, or to any build flag. If the cache is cold or the action is
unavailable, the build proceeds exactly as it does today.
